### PR TITLE
Always BasicAPI last to prevent overriding when Raw at root is used

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -67,9 +67,9 @@ type BasicAPI = Get '[PlainText, JSON] Text
 type SwaggerSchemaEndpoint = "swagger.js" :> Get '[JSON] Swagger
 
 data API
-type API' = BasicAPI
-    :<|> SwaggerSchemaEndpoint
+type API' = SwaggerSchemaEndpoint
     :<|> SwaggerUI "ui" SwaggerSchemaEndpoint API
+    :<|> BasicAPI
 
 instance HasServer API
 #if MIN_VERSION_servant(0,5,0)
@@ -83,10 +83,9 @@ type instance IsElem' e API = IsElem e API'
 
 -- Implementation
 server :: Server API
-server =
-    (return "Hello World" :<|> catEndpoint :<|> catEndpoint :<|> catEndpoint)
-    :<|> return swaggerDoc
+server = return swaggerDoc
     :<|> swaggerUIServer
+    :<|> (return "Hello World" :<|> catEndpoint :<|> catEndpoint :<|> catEndpoint)
   where
     catEndpoint n = return $ Cat n False
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,5 @@
-resolver: nightly-2016-05-29
+resolver: nightly-2016-07-19
 packages:
 - '.'
-extra-deps:
-- swagger2-2.1
-- servant-swagger-1.1
+extra-deps: []
 flags: {}


### PR DESCRIPTION
Having `Raw` for root is probably bad, however, it happens and in that case `Raw` should be last endpoint to check.